### PR TITLE
Various fixes

### DIFF
--- a/news/35.bugfix.1
+++ b/news/35.bugfix.1
@@ -1,0 +1,2 @@
+Do not export or import translations when `plone.app.multilingual` is not available.
+[maurits]

--- a/news/35.bugfix.2
+++ b/news/35.bugfix.2
@@ -1,0 +1,2 @@
+Do not export or import discussions/comments when `plone.app.discussion` is not available.
+[maurits]

--- a/news/35.bugfix.3
+++ b/news/35.bugfix.3
@@ -1,0 +1,2 @@
+Add a fixer for the `allow_discussion` key: this should only contain True or False when this is explicitly set on the object.
+[maurits]

--- a/news/35.bugfix.4
+++ b/news/35.bugfix.4
@@ -1,0 +1,2 @@
+Disallowlisted portlets were not imported when there was no accompanying change in the actual portlet list.
+[maurits]

--- a/news/35.bugfix.5
+++ b/news/35.bugfix.5
@@ -1,0 +1,3 @@
+Renamed `blacklisted_status` key to `disallowlisted_status` to be sensitive.
+We still read the old key for backwards compatibility.
+[maurits]

--- a/news/35.bugfix.5
+++ b/news/35.bugfix.5
@@ -1,3 +1,3 @@
-Renamed `blacklisted_status` key to `disallowlisted_status` to be sensitive.
+Renamed `blacklisted_status` key to `blocked_status` to be sensitive.
 We still read the old key for backwards compatibility.
 [maurits]

--- a/news/35.bugfix.6
+++ b/news/35.bugfix.6
@@ -1,0 +1,3 @@
+Export adds a newline at the end of all files.
+This matches the `.editorconfig` settings that we have in most Plone packages.
+[maurits]

--- a/src/plone/exportimport/exporters/__init__.py
+++ b/src/plone/exportimport/exporters/__init__.py
@@ -70,9 +70,7 @@ class Exporter:
             for exporter_name, exporter in self.exporters.items():
                 logger.debug(f"Exporting {self.site} with {exporter_name} to {path}")
                 new_paths = exporter.export_data(path)
-                # could be None
-                if new_paths:
-                    paths.extend(new_paths)
+                paths.extend(new_paths)
         return paths
 
 

--- a/src/plone/exportimport/exporters/__init__.py
+++ b/src/plone/exportimport/exporters/__init__.py
@@ -69,7 +69,10 @@ class Exporter:
         with hooks.site(self.site):
             for exporter_name, exporter in self.exporters.items():
                 logger.debug(f"Exporting {self.site} with {exporter_name} to {path}")
-                paths.extend(exporter.export_data(path))
+                new_paths = exporter.export_data(path)
+                # could be None
+                if new_paths:
+                    paths.extend(new_paths)
         return paths
 
 

--- a/src/plone/exportimport/exporters/base.py
+++ b/src/plone/exportimport/exporters/base.py
@@ -44,6 +44,12 @@ class BaseExporter:
         path_utils.get_parent_folder(filepath)
         with open(filepath, "w") as fh:
             json.dump(data, fh, indent=2, sort_keys=True)
+            # json.dump does not add a newline at the end of the file, so we
+            # explicitly do it.  Otherwise when you manually edit a file and
+            # you use an editor that respects the standard `.editorconfig`
+            # that we have in most Plone packages, you always get a diff because
+            # your editor has automatically added a newline at the end.
+            fh.write("\n")
         return filepath
 
     def dump(self) -> List[Path]:

--- a/src/plone/exportimport/exporters/configure.zcml
+++ b/src/plone/exportimport/exporters/configure.zcml
@@ -33,19 +33,22 @@
       for="plone.base.interfaces.siteroot.IPloneSiteRoot"
       name="plone.exporter.relations"
       />
-  <adapter
-      factory=".translations.TranslationsExporter"
-      provides="plone.exportimport.interfaces.INamedExporter"
-      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
-      name="plone.exporter.translations"
-      />
-  <adapter
-      factory=".discussions.DiscussionsExporter"
-      provides="plone.exportimport.interfaces.INamedExporter"
-      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
-      name="plone.exporter.discussions"
-      />
-
+  <configure zcml:condition="installed plone.app.multilingual">
+    <adapter
+        factory=".translations.TranslationsExporter"
+        provides="plone.exportimport.interfaces.INamedExporter"
+        for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+        name="plone.exporter.translations"
+        />
+  </configure>
+  <configure zcml:condition="installed plone.app.discussion">
+    <adapter
+        factory=".discussions.DiscussionsExporter"
+        provides="plone.exportimport.interfaces.INamedExporter"
+        for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+        name="plone.exporter.discussions"
+        />
+  </configure>
   <configure zcml:condition="installed plone.app.portlets">
     <adapter
         factory=".portlets.PortletsExporter"

--- a/src/plone/exportimport/exporters/discussions.py
+++ b/src/plone/exportimport/exporters/discussions.py
@@ -22,7 +22,7 @@ class DiscussionsExporter(BaseExporter):
         """Serialize object and dump it to disk."""
         if not HAS_DISCUSSION:
             logger.debug("- Discussions: Skipping (plone.app.discussion not installed)")
-            return
+            return []
 
         from plone.exportimport.utils import discussions as utils
 

--- a/src/plone/exportimport/importers/configure.zcml
+++ b/src/plone/exportimport/importers/configure.zcml
@@ -33,19 +33,22 @@
       for="plone.base.interfaces.siteroot.IPloneSiteRoot"
       name="plone.importer.relations"
       />
-  <adapter
-      factory=".translations.TranslationsImporter"
-      provides="plone.exportimport.interfaces.INamedImporter"
-      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
-      name="plone.importer.translations"
-      />
-  <adapter
-      factory=".discussions.DiscussionsImporter"
-      provides="plone.exportimport.interfaces.INamedImporter"
-      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
-      name="plone.importer.discussions"
-      />
-
+  <configure zcml:condition="installed plone.app.multilingual">
+    <adapter
+        factory=".translations.TranslationsImporter"
+        provides="plone.exportimport.interfaces.INamedImporter"
+        for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+        name="plone.importer.translations"
+        />
+  </configure>
+  <configure zcml:condition="installed plone.app.discussion">
+    <adapter
+        factory=".discussions.DiscussionsImporter"
+        provides="plone.exportimport.interfaces.INamedImporter"
+        for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+        name="plone.importer.discussions"
+        />
+  </configure>
   <configure zcml:condition="installed plone.app.portlets">
     <adapter
         factory=".portlets.PortletsImporter"

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -143,6 +143,33 @@ def fix_root_uid(
     return json.loads(item_str)
 
 
+def fix_allow_discussion(
+    item: dict, obj: DexterityContent, config: types.ExporterConfig
+) -> dict:
+    """Fix allow_discussion key.
+
+    Currently, plone.restapi always adds the 'allow_discussion' key.
+    This contains either True or False, based on various facts:
+
+    * Is the plone.app.discussion package available?
+    * Is the plone.app.discussion add-on activated?
+    * Is discussion globally allowed?
+    * Is discussion allowed on this portal type?
+    * Is discussion explicitly allowed on this object?
+
+    For exporting we only want the last one.
+    Otherwise when one of the other facts is not true at the moment of export,
+    then all content would get allow_discussion=false.
+    Then when someone imports it, and afterwards wants to globally allow discussions,
+    they would need to go through all content and explicitly set allow_discussion
+    to true or to none.
+
+    So: here we set the value to neutral (None), unless it is explicitly set.
+    """
+    item["allow_discussion"] = getattr(aq_base(obj), "allow_discussion", None)
+    return item
+
+
 def add_constrains_info(obj: DexterityContent, config: types.ExporterConfig) -> dict:
     """Return constrains info for an object."""
     key = settings.SERIALIZER_CONSTRAINS_KEY
@@ -268,6 +295,7 @@ def fixers() -> List[types.ExportImportHelper]:
         fix_blocks,
         fix_language,
         fix_root_uid,
+        fix_allow_discussion,
     ]
     for func in funcs:
         fixers.append(

--- a/src/plone/exportimport/utils/translations.py
+++ b/src/plone/exportimport/utils/translations.py
@@ -115,10 +115,10 @@ def link_translations(
 
 def set_translations(data: List[dict]) -> List[dict]:
     """Process a list of translations and add them to the Plone site."""
+    results = []
     if not HAS_MULTILINGUAL:
         logger.warning("- Translation: Skipping (plone.app.multilingual not installed)")
-        return
-    results = []
+        return results
     for item in data:
         translation_group = _parse_translation_group(item)
         canonical = translation_group["canonical"]

--- a/tests/_resources/base_import/portlets.json
+++ b/tests/_resources/base_import/portlets.json
@@ -66,7 +66,7 @@
   },
   {
     "@id": "http://localhost:8080/plone.pdf",
-    "blacklist_status": [
+    "disallowlist_status": [
       {
         "category": "group",
         "manager": "plone.rightcolumn",

--- a/tests/_resources/base_import/portlets.json
+++ b/tests/_resources/base_import/portlets.json
@@ -66,7 +66,7 @@
   },
   {
     "@id": "http://localhost:8080/plone.pdf",
-    "disallowlist_status": [
+    "blocked_status": [
       {
         "category": "group",
         "manager": "plone.rightcolumn",

--- a/tests/_resources/portlets_import/portlets.json
+++ b/tests/_resources/portlets_import/portlets.json
@@ -1,7 +1,7 @@
 [
   {
     "@id": "http://localhost:8080/Plone",
-    "blacklist_status": [
+    "disallowlist_status": [
       {
         "category": "context",
         "manager": "plone.rightcolumn",

--- a/tests/_resources/portlets_import/portlets.json
+++ b/tests/_resources/portlets_import/portlets.json
@@ -1,7 +1,7 @@
 [
   {
     "@id": "http://localhost:8080/Plone",
-    "disallowlist_status": [
+    "blocked_status": [
       {
         "category": "context",
         "manager": "plone.rightcolumn",

--- a/tests/exporters/test_exporters_portlets.py
+++ b/tests/exporters/test_exporters_portlets.py
@@ -66,7 +66,7 @@ class TestExporterPortlets:
         "key,value_type",
         [
             ["portlets", dict],
-            ["disallowlist_status", list],
+            ["blocked_status", list],
         ],
     )
     def test_portlets_content_specific(self, export_path, load_json, key, value_type):
@@ -74,7 +74,7 @@ class TestExporterPortlets:
         exporter.export_data(base_path=export_path)
         data = load_json(base_path=export_path, path="portlets.json")
         assert isinstance(data, list)
-        # We expect at least one to have a disallowlist, and another to have portlets.
+        # We expect at least one to have a blocked_status, and another to have portlets.
         # The order could possibly differ, so look for the first one that matches.
         for portlet in data:
             if key in portlet:

--- a/tests/exporters/test_exporters_portlets.py
+++ b/tests/exporters/test_exporters_portlets.py
@@ -66,7 +66,7 @@ class TestExporterPortlets:
         "key,value_type",
         [
             ["portlets", dict],
-            ["blacklist_status", list],
+            ["disallowlist_status", list],
         ],
     )
     def test_portlets_content_specific(self, export_path, load_json, key, value_type):
@@ -74,7 +74,7 @@ class TestExporterPortlets:
         exporter.export_data(base_path=export_path)
         data = load_json(base_path=export_path, path="portlets.json")
         assert isinstance(data, list)
-        # We expect at least one to have a blacklist, and another to have portlets.
+        # We expect at least one to have a disallowlist, and another to have portlets.
         # The order could possibly differ, so look for the first one that matches.
         for portlet in data:
             if key in portlet:

--- a/tests/exporters/test_exporters_portlets.py
+++ b/tests/exporters/test_exporters_portlets.py
@@ -50,11 +50,10 @@ class TestExporterPortlets:
         "key,value_type",
         [
             ["@id", str],
-            ["portlets", dict],
             ["UID", str],
         ],
     )
-    def test_portlets_content(self, export_path, load_json, key, value_type):
+    def test_portlets_content_general(self, export_path, load_json, key, value_type):
         exporter = self.exporter
         exporter.export_data(base_path=export_path)
         data = load_json(base_path=export_path, path="portlets.json")
@@ -62,3 +61,24 @@ class TestExporterPortlets:
         portlet = data[0]
         assert key in portlet
         assert isinstance(portlet[key], value_type)
+
+    @pytest.mark.parametrize(
+        "key,value_type",
+        [
+            ["portlets", dict],
+            ["blacklist_status", list],
+        ],
+    )
+    def test_portlets_content_specific(self, export_path, load_json, key, value_type):
+        exporter = self.exporter
+        exporter.export_data(base_path=export_path)
+        data = load_json(base_path=export_path, path="portlets.json")
+        assert isinstance(data, list)
+        # We expect at least one to have a blacklist, and another to have portlets.
+        # The order could possibly differ, so look for the first one that matches.
+        for portlet in data:
+            if key in portlet:
+                assert isinstance(portlet[key], value_type)
+                return
+        # If we end up here, the key was found nowhere.
+        assert False, f"{key} key not found in anywhere in {data}"


### PR DESCRIPTION
I was testing https://github.com/plone/plone.classicui/pull/13 and this led to some improvements.  See individual commit messages for details, but largely it is this:

* Do not export or import translations when `plone.app.multilingual` is not available.  I got an error initially.
* Do not export or import discussions/comments when `plone.app.discussion` is not available.
* Add a fixer for the `allow_discussion` key: this should only contain True or False when this is explicitly set on the object.
* Blacklisted portlets were not imported when there was no accompanying change in the actual portlet list.  Practically speaking: the distribution blacklists some portlets in the Members folder, but this was ignored on import.
* Export adds a newline at the end of all files.  This matches the `.editorconfig` settings that we have in most Plone packages.

I have used this code to import and export a Classic UI site with the mentioned `plone.classicui` pull request, and have updated it.

BTW, is it too late in the `portlets.json` to rename `blacklist_status` to something like `disallowlist_status`?  I don't feel strongly about this, but using "black" in this context is frowned upon.  For backwards compatibility we could still read the old name as well.