### PR TITLE
Sustainable exports, part 1

### DIFF
--- a/news/39.bugfix.1
+++ b/news/39.bugfix.1
@@ -1,0 +1,1 @@
+Export principals: sort groups and roles.  @mauritsvanrees

--- a/news/39.bugfix.2
+++ b/news/39.bugfix.2
@@ -1,0 +1,1 @@
+Import: update dates again at the end. The original modification dates may have changed.  @mauritsvanrees

--- a/news/39.bugfix.3
+++ b/news/39.bugfix.3
@@ -1,0 +1,1 @@
+Do not export parent info.  This information is not needed.  @mauritsvanrees

--- a/src/plone/exportimport/importers/__init__.py
+++ b/src/plone/exportimport/importers/__init__.py
@@ -20,6 +20,7 @@ IMPORTER_NAMES = [
     "plone.importer.translations",
     "plone.importer.discussions",
     "plone.importer.portlets",
+    "plone.importer.contentfinal",
 ]
 
 ImporterMapping = Dict[str, BaseImporter]

--- a/src/plone/exportimport/importers/configure.zcml
+++ b/src/plone/exportimport/importers/configure.zcml
@@ -16,6 +16,12 @@
       name="plone.importer.content"
       />
   <adapter
+      factory=".content.ContentFinalImporter"
+      provides="plone.exportimport.interfaces.INamedImporter"
+      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+      name="plone.importer.contentfinal"
+      />
+  <adapter
       factory=".principals.PrincipalsImporter"
       provides="plone.exportimport.interfaces.INamedImporter"
       for="plone.base.interfaces.siteroot.IPloneSiteRoot"

--- a/src/plone/exportimport/utils/content/__init__.py
+++ b/src/plone/exportimport/utils/content/__init__.py
@@ -10,6 +10,7 @@ from .export_helpers import enrichers  # noQA
 from .export_helpers import fixers  # noQA
 from .export_helpers import get_serializer  # noQA
 from .export_helpers import metadata_helpers  # noQA
+from .import_helpers import final_updaters  # noQA
 from .import_helpers import get_deserializer  # noQA
 from .import_helpers import get_obj_instance  # noQA
 from .import_helpers import metadata_setters  # noQA

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -63,6 +63,7 @@ def cleanup_export_data(item: dict, config: types.ExporterConfig) -> dict:
     item.pop("previous_item", None)
     item.pop("immediatelyAddableTypes", None)
     item.pop("locallyAllowedTypes", None)
+    item.pop("parent", None)
 
     # 2. Fix site root
     item = rewrite_site_root(item, config.site.absolute_url())

--- a/src/plone/exportimport/utils/principals/members.py
+++ b/src/plone/exportimport/utils/principals/members.py
@@ -78,8 +78,8 @@ def _get_base_user_data(member: MemberData):
     # username, groups, roles
     props = {
         "username": user_id,
-        "roles": json_compatible(roles),
-        "groups": json_compatible(groups),
+        "roles": json_compatible(sorted(roles)),
+        "groups": json_compatible(sorted(groups)),
     }
     return props
 


### PR DESCRIPTION
See issue #36 and #39.

* Export principals: I saw roles in a different order when exporting a second time, so now we sort them.  Same for groups.
* Do not export the parent info, this is not needed.  Instead, use the path of the item, and get the parent path.  This makes the export shorter.
  * Possible downside: if you are using this to do partial imports, and you have renamed the parent folder, then you can no longer find it.  Previously, you could still find the renamed parent via its UID.
  * Possible upside: you can then manually create a matching folder structure, and do an import, without needing to somehow change the UID of the manually created folder.
  * Both those points are irrelevant though for the main use case of creating a new site using a distribution.
  * I guess we could make this optional: by default do not export the parent info, but allow exporting it using a command line argument, and then still use the parent info during import.
* Import: set the modified (and created) dates again at the end.  In the `content` importer they are already set correctly during import of an item.  But importing a child item may change the modified date of a parent folder.  And the `relations` importer may also change the modified date of an item.  So at the end of the importers list, we add a `contentfinal` importer which sets the modified date again.  Note that this rereads all content json files.