### PR TITLE
Do not export parent info.  This information is not needed.

### DIFF
--- a/news/39.bugfix.3
+++ b/news/39.bugfix.3
@@ -1,0 +1,1 @@
+Do not export parent info.  This information is not needed.  @mauritsvanrees

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -63,6 +63,7 @@ def cleanup_export_data(item: dict, config: types.ExporterConfig) -> dict:
     item.pop("previous_item", None)
     item.pop("immediatelyAddableTypes", None)
     item.pop("locallyAllowedTypes", None)
+    item.pop("parent", None)
 
     # 2. Fix site root
     item = rewrite_site_root(item, config.site.absolute_url())

--- a/tests/importers/test_importers_content.py
+++ b/tests/importers/test_importers_content.py
@@ -94,3 +94,47 @@ class TestImporterConstrains:
             constrains = getattr(behavior, method)()
         for type_ in types:
             assert type_ in constrains
+
+
+class TestImporterParent:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal, base_import_path, load_json):
+        self.portal = portal
+        importer = content.ContentImporter(portal)
+        importer.import_data(base_path=base_import_path)
+
+    @pytest.mark.parametrize(
+        "data,path",
+        [
+            [
+                {"@type": "Plone Site"},
+                "/",
+            ],
+            [
+                {"@id": "/bar"},
+                "/plone",
+            ],
+            [
+                {"@id": "/bar/2025.png"},
+                "/plone/bar",
+            ],
+            [
+                {"@id": "/bar/2025.png/parent-is-not-folderish"},
+                None,
+            ],
+            [
+                {"@id": "/foo/not-yet-created"},
+                "/plone/foo",
+            ],
+            [
+                {"@id": "/spaghetti/bolognese"},
+                None,
+            ],
+        ],
+    )
+    def test_get_parent_from_item(self, data, path):
+        from plone.exportimport.utils.content.import_helpers import get_parent_from_item
+
+        parent = get_parent_from_item(data)
+        found_path = parent.absolute_url_path() if parent is not None else None
+        assert found_path == path


### PR DESCRIPTION
Add tests for `get_parent_from_item`, so we can see that it still works.

Part of issue #39.