### PR TITLE
Import: update dates again at the end.

### DIFF
--- a/news/39.bugfix.2
+++ b/news/39.bugfix.2
@@ -1,0 +1,1 @@
+Import: update dates again at the end. The original modification dates may have changed.  @mauritsvanrees

--- a/src/plone/exportimport/importers/__init__.py
+++ b/src/plone/exportimport/importers/__init__.py
@@ -20,6 +20,7 @@ IMPORTER_NAMES = [
     "plone.importer.translations",
     "plone.importer.discussions",
     "plone.importer.portlets",
+    "plone.importer.contentfinal",
 ]
 
 ImporterMapping = Dict[str, BaseImporter]

--- a/src/plone/exportimport/importers/configure.zcml
+++ b/src/plone/exportimport/importers/configure.zcml
@@ -16,6 +16,12 @@
       name="plone.importer.content"
       />
   <adapter
+      factory=".content.ContentFinalImporter"
+      provides="plone.exportimport.interfaces.INamedImporter"
+      for="plone.base.interfaces.siteroot.IPloneSiteRoot"
+      name="plone.importer.contentfinal"
+      />
+  <adapter
       factory=".principals.PrincipalsImporter"
       provides="plone.exportimport.interfaces.INamedImporter"
       for="plone.base.interfaces.siteroot.IPloneSiteRoot"

--- a/src/plone/exportimport/utils/content/__init__.py
+++ b/src/plone/exportimport/utils/content/__init__.py
@@ -10,6 +10,7 @@ from .export_helpers import enrichers  # noQA
 from .export_helpers import fixers  # noQA
 from .export_helpers import get_serializer  # noQA
 from .export_helpers import metadata_helpers  # noQA
+from .import_helpers import final_updaters  # noQA
 from .import_helpers import get_deserializer  # noQA
 from .import_helpers import get_obj_instance  # noQA
 from .import_helpers import metadata_setters  # noQA

--- a/tests/importers/test_importers_contentfinal.py
+++ b/tests/importers/test_importers_contentfinal.py
@@ -1,0 +1,88 @@
+from DateTime import DateTime
+from plone.exportimport import interfaces
+from plone.exportimport.importers import content
+from zope.component import getAdapter
+
+import pytest
+
+
+class TestImporterContent:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_multilingual_content):
+        self.portal = portal_multilingual_content
+        # The contentfinal importer is an enhancement on the content importer.
+        # That one needs to run first.
+        self.content_importer = content.ContentImporter(self.portal)
+        self.importer = content.ContentFinalImporter(self.portal)
+
+    def test_adapter_is_registered(self):
+        adapter = getAdapter(
+            self.portal, interfaces.INamedImporter, "plone.importer.contentfinal"
+        )
+        assert isinstance(adapter, content.ContentFinalImporter)
+
+    def test_output_is_str(self, multilingual_import_path):
+        self.content_importer.import_data(base_path=multilingual_import_path)
+        importer = self.importer
+        result = importer.import_data(base_path=multilingual_import_path)
+        assert isinstance(result, str)
+        assert result == "ContentFinalImporter: Updated 19 objects"
+
+    def test_empty_import_path(self, empty_import_path):
+        importer = self.importer
+        result = importer.import_data(base_path=empty_import_path)
+        assert isinstance(result, str)
+        assert result == "ContentFinalImporter: No data to import"
+
+
+class TestImporterDates:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal, base_import_path, load_json):
+        self.portal = portal
+        content_importer = content.ContentImporter(self.portal)
+        content_importer.import_data(base_path=base_import_path)
+        importer = content.ContentFinalImporter(portal)
+        importer.import_data(base_path=base_import_path)
+
+    @pytest.mark.parametrize(
+        "uid,method_name,value",
+        [
+            [
+                "35661c9bb5be42c68f665aa1ed291418",
+                "created",
+                "2024-02-13T18:16:04+00:00",
+            ],
+            [
+                "35661c9bb5be42c68f665aa1ed291418",
+                "modified",
+                "2024-02-13T18:16:04+00:00",
+            ],
+            [
+                "3e0dd7c4b2714eafa1d6fc6a1493f953",
+                "created",
+                "2024-03-19T19:02:18+00:00",
+            ],
+            [
+                "3e0dd7c4b2714eafa1d6fc6a1493f953",
+                "modified",
+                "2024-03-19T19:02:18+00:00",
+            ],
+            [
+                "e7359727ace64e609b79c4091c38822a",
+                "created",
+                "2024-02-13T18:15:56+00:00",
+            ],
+            # Note: this would fail without the contentfinal importer, because this
+            # is a folder that gets modified later when a document is added.
+            [
+                "e7359727ace64e609b79c4091c38822a",
+                "modified",
+                "2024-02-13T20:51:06+00:00",
+            ],
+        ],
+    )
+    def test_date_is_set(self, uid, method_name, value):
+        from plone.exportimport.utils.content import object_from_uid
+
+        content = object_from_uid(uid)
+        assert getattr(content, method_name)() == DateTime(value)


### PR DESCRIPTION
The original modification dates may have changed.

This is done by adding another importer that is run at the end: `plone.importer.contentfinal`. Note that this iterates over the same content jsons again.