### PR TITLE
Include revisions only when passing --include-revisions.

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -77,13 +77,16 @@ Export content from a Plone site to a directory in the file system.
 
 Usage:
 
-  - `plone-exporter` <path-to-zopeconf> <site-id> <path-to-export-data>
+  - `plone-exporter` [--include-revisions] <path-to-zopeconf> <site-id> <path-to-export-data>
 
 Example:
 
 ```shell
 plone-exporter instance/etc/zope.conf Plone /tmp/plone_data/
 ```
+
+By default, the revisions history (older versions of each content item) are not exported.
+If you do want them, add `--include-revisions` on the command line.
 
 ## `plone-importer`
 

--- a/news/39.feature.4
+++ b/news/39.feature.4
@@ -1,0 +1,1 @@
+Include revisions only when passing `--include-revisions`.  @mauritsvanrees

--- a/src/plone/exportimport/cli/__init__.py
+++ b/src/plone/exportimport/cli/__init__.py
@@ -15,6 +15,7 @@ CLI_SPEC = {
             "zopeconf": "Path to zope.conf",
             "site": "Plone site ID to export the content from",
             "path": "Path to export the content",
+            "--include-revisions": "Include revision history",
         },
     },
     "importer": {
@@ -31,7 +32,10 @@ CLI_SPEC = {
 def _parse_args(description: str, options: dict, args: list):
     parser = argparse.ArgumentParser(description=description)
     for key, help in options.items():
-        parser.add_argument(key, help=help)
+        if key.startswith("-"):
+            parser.add_argument(key, action="store_true", help=help)
+        else:
+            parser.add_argument(key, help=help)
     namespace, _ = parser.parse_known_args(args[1:])
     return namespace
 
@@ -40,6 +44,7 @@ def exporter_cli(args=sys.argv):
     """Export a Plone site."""
     logger = cli_helpers.get_logger("Exporter")
     exporter_cli = CLI_SPEC["exporter"]
+    # We get an argparse.Namespace instance.
     namespace = _parse_args(exporter_cli["description"], exporter_cli["options"], args)
     app = cli_helpers.get_app(namespace.zopeconf)
     path = cli_helpers._process_path(namespace.path)
@@ -48,7 +53,7 @@ def exporter_cli(args=sys.argv):
         sys.exit(1)
     site = cli_helpers.get_site(app, namespace.site, logger)
     with api.env.adopt_roles(["Manager"]):
-        results = get_exporter(site).export_site(path)
+        results = get_exporter(site).export_site(path, options=namespace)
     logger.info(f" Using path {path} to export content from Plone site at /{site.id}")
     for item in results[1:]:
         logger.info(f" Wrote {item}")

--- a/src/plone/exportimport/exporters/__init__.py
+++ b/src/plone/exportimport/exporters/__init__.py
@@ -14,6 +14,8 @@ from zope.component import hooks
 from zope.component import queryAdapter
 from zope.interface import implementer
 
+import argparse
+
 
 EXPORTER_NAMES = [
     "plone.exporter.content",
@@ -62,14 +64,16 @@ class Exporter:
             path = Path(mkdtemp(prefix=PACKAGE_NAME))
         return path
 
-    def export_site(self, path: Optional[Path] = None) -> List[Path]:
+    def export_site(
+        self, path: Optional[Path] = None, options: Optional[argparse.Namespace] = None
+    ) -> List[Path]:
         """Export the given site to the filesystem."""
         path = self._prepare_path(path)
         paths: List[Path] = [path]
         with hooks.site(self.site):
             for exporter_name, exporter in self.exporters.items():
                 logger.debug(f"Exporting {self.site} with {exporter_name} to {path}")
-                new_paths = exporter.export_data(path)
+                new_paths = exporter.export_data(path, options=options)
                 paths.extend(new_paths)
         return paths
 

--- a/src/plone/exportimport/exporters/base.py
+++ b/src/plone/exportimport/exporters/base.py
@@ -6,8 +6,10 @@ from Products.CMFPlone.Portal import PloneSite
 from typing import Any
 from typing import Callable
 from typing import List
+from typing import Optional
 from zope.globalrequest import getRequest
 
+import argparse
 import json
 
 
@@ -18,6 +20,7 @@ class BaseExporter:
     request: types.HTTPRequest = None
     data_hooks: List[Callable] = None
     obj_hooks: List[Callable] = None
+    options: Optional[argparse.Namespace] = None
 
     def __init__(
         self,
@@ -26,6 +29,9 @@ class BaseExporter:
         self.site = site
         self.errors = []
         self.request = getRequest()
+
+    def get_option(self, name, default=None):
+        return getattr(self.options, name, default)
 
     @property
     def filepath(self) -> Path:
@@ -61,6 +67,7 @@ class BaseExporter:
         base_path: Path,
         data_hooks: List[Callable] = None,
         obj_hooks: List[Callable] = None,
+        options: Optional[argparse.Namespace] = None,
     ) -> List[Path]:
         """Write data to filesystem."""
         if not base_path.exists():
@@ -68,5 +75,6 @@ class BaseExporter:
         self.base_path = base_path
         self.data_hooks = self.data_hooks or data_hooks or []
         self.obj_hooks = self.obj_hooks or obj_hooks or []
+        self.options = options
         paths = self.dump()
         return paths

--- a/src/plone/exportimport/exporters/content.py
+++ b/src/plone/exportimport/exporters/content.py
@@ -132,7 +132,7 @@ class ContentExporter(BaseExporter):
         filepath = self.base_path / "__metadata__.json"
         return self._dump(metadata, filepath)
 
-    def dump(self, **kwargs) -> List[Path]:
+    def dump(self) -> List[Path]:
         """Serialize contents and dump them to disk."""
         paths = []
         with request_provides(self.request, IExportImportRequestMarker):

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -308,13 +308,14 @@ def fixers() -> List[types.ExportImportHelper]:
     return fixers
 
 
-def enrichers() -> List[types.ExportImportHelper]:
+def enrichers(include_revisions: bool = False) -> List[types.ExportImportHelper]:
     enrichers = []
     funcs = [
         add_constraints_info,
         add_workflow_history,
-        add_revisions_history,
     ]
+    if include_revisions:
+        funcs.append(add_revisions_history)
     if IConversation is not None:
         funcs.append(add_conversation)
     for func in funcs:

--- a/src/plone/exportimport/utils/content/import_helpers.py
+++ b/src/plone/exportimport/utils/content/import_helpers.py
@@ -117,9 +117,17 @@ def get_obj_instance(item: dict, config: types.ImporterConfig) -> DexterityConte
         logger.debug(f"{config.logger_prefix} Will update {new}")
     else:
         factory_kwargs = item.get("factory_kwargs", {})
-        new = unrestricted_construct_instance(
-            item["@type"], container, item["id"], **factory_kwargs
-        )
+        repo_tool = api.portal.get_tool("portal_repository")
+        # Temporarily disable versioning, otherwise the first version
+        # is basically nothing, it does not even have a title.
+        orig_versionable = repo_tool.getVersionableContentTypes()
+        repo_tool.setVersionableContentTypes([])
+        try:
+            new = unrestricted_construct_instance(
+                item["@type"], container, item["id"], **factory_kwargs
+            )
+        finally:
+            repo_tool.setVersionableContentTypes(orig_versionable)
         logger.debug(f"{config.logger_prefix} Created {new}")
     return new
 


### PR DESCRIPTION
Also temporarily disable versioning when creating a bare content object. Otherwise the first version is basically nothing, it does not even have a title.