### PR TITLE
Export the raw value of rich text fields

### DIFF
--- a/news/48.bugfix
+++ b/news/48.bugfix
@@ -1,0 +1,3 @@
+Export the raw value of rich text fields, instead of the transformed output.
+This fixes internal links in Classic UI based distributions.
+@mauritsvanrees

--- a/src/plone/exportimport/serializers/configure.zcml
+++ b/src/plone/exportimport/serializers/configure.zcml
@@ -6,4 +6,5 @@
   <adapter factory=".blocks.ExportImportBlocksSerializer" />
   <adapter factory=".fields.CollectionFieldSerializer" />
   <adapter factory=".fields.ChoiceFieldSerializer" />
+  <adapter factory=".fields.ExportImportRichTextSerializer" />
 </configure>

--- a/src/plone/exportimport/serializers/fields.py
+++ b/src/plone/exportimport/serializers/fields.py
@@ -1,3 +1,5 @@
+from plone.app.textfield.interfaces import IRichText
+from plone.app.textfield.interfaces import IRichTextValue
 from plone.dexterity.interfaces import IDexterityContent
 from plone.exportimport.interfaces import IExportImportRequestMarker
 from plone.restapi.interfaces import IFieldSerializer
@@ -76,3 +78,16 @@ class ChoiceFieldSerializer(DefaultFieldSerializer):
                         self.context,
                     )
         return json_compatible(value)
+
+
+@adapter(IRichText, IDexterityContent, IExportImportRequestMarker)
+class ExportImportRichTextSerializer(DefaultFieldSerializer):
+    def __call__(self):
+        value = self.get_value()
+        if value is None or not IRichTextValue.providedBy(value):
+            return json_compatible(value, self.context)
+        return {
+            "data": json_compatible(value.raw),
+            "content-type": json_compatible(value.mimeType),
+            "encoding": json_compatible(value.encoding),
+        }


### PR DESCRIPTION
This is instead of the transformed output.  This fixes internal links in Classic UI based distributions.  Fixes issue #48.

Sample difference in output:

```
<     "data": "<p>Link to <a href=\"http://nohost/Plone/news\">news</a>.</p>",
---
>     "data": "<p>Link to <a href=\"resolveuid/4053ffb6901342ac991afb54da15ab77\" data-linktype=\"internal\" data-val=\"4053ffb6901342ac991afb54da15ab77\">news</a>.</p>",
```