### PR TITLE
Sort `relations.json` and `translations.json` so they are stable

### DIFF
--- a/news/57.bugfix
+++ b/news/57.bugfix
@@ -1,0 +1,1 @@
+Sort `relations.json` and `translations.json` so their contents are stable.  @mauritsvanrees

--- a/src/plone/exportimport/utils/relations.py
+++ b/src/plone/exportimport/utils/relations.py
@@ -58,6 +58,10 @@ def _should_export_relation(rel: dict, include_linkintegrity: bool) -> bool:
     return status and (not is_linkintegrity or include_linkintegrity)
 
 
+def _relation_sort_key(rel: dict) -> tuple:
+    return rel.get("from_uuid"), rel.get("from_attribute"), rel.get("to_uuid")
+
+
 def get_relations(
     debug: bool = False, include_linkintegrity: bool = True
 ) -> List[dict]:
@@ -69,7 +73,7 @@ def get_relations(
         if debug:
             rel = _relation_with_debug_information(rel)
         results.append(rel)
-    return results
+    return sorted(results, key=_relation_sort_key)
 
 
 def _prepare_relations_to_import(data: List[dict]) -> List[dict]:

--- a/src/plone/exportimport/utils/translations.py
+++ b/src/plone/exportimport/utils/translations.py
@@ -7,6 +7,8 @@ from Products.CMFPlone.CatalogTool import CatalogTool
 from typing import List
 from typing import Tuple
 
+import operator
+
 
 try:
     from plone.app.multilingual.interfaces import ITranslationManager
@@ -77,7 +79,7 @@ def get_translations(paths_to_drop: List[str] = None) -> List[dict]:
 
         if len(translations) > 1:
             results.append(_prepare_translation_group(default_language, translations))
-    return results
+    return sorted(results, key=operator.itemgetter("canonical"))
 
 
 def _parse_translation_group(translation_group: dict) -> dict:


### PR DESCRIPTION
Fixes https://github.com/plone/plone.exportimport/issues/57