### PR TITLE
#66 export paths in json as posix

### DIFF
--- a/news/66.bugfix
+++ b/news/66.bugfix
@@ -1,0 +1,1 @@
+Export all paths in Posix format to support export-import across platforms [ewohnlich]

--- a/src/plone/exportimport/exporters/content.py
+++ b/src/plone/exportimport/exporters/content.py
@@ -124,7 +124,7 @@ class ContentExporter(BaseExporter):
         filepath = self._dump(data, filepath)
         logger.debug(f"- {obj_path}: Wrote serialized data to {filepath}")
         # Add to list of files
-        self.metadata._all_[obj_path] = str(filepath.relative_to(base_path))
+        self.metadata._all_[obj_path] = str(filepath.relative_to(base_path).as_posix())
         return filepath
 
     def dump_metadata(self) -> Path:

--- a/src/plone/exportimport/serializers/blob.py
+++ b/src/plone/exportimport/serializers/blob.py
@@ -32,7 +32,7 @@ class ExportImportFileFieldSerializer(DefaultFieldSerializer):
                 "filename": namedfile.filename,
                 "content-type": namedfile.contentType,
                 "size": namedfile.getSize(),
-                "blob_path": str(blob_path),
+                "blob_path": str(blob_path.as_posix()),
             }
             return json_compatible(result)
 
@@ -60,7 +60,7 @@ class ExportImportImageFieldSerializer(DefaultFieldSerializer):
             "size": namedfile.getSize(),
             "width": width,
             "height": height,
-            "blob_path": str(blob_path),
+            "blob_path": str(blob_path.as_posix()),
         }
         return json_compatible(result)
 
@@ -96,5 +96,5 @@ def export_blob(
         f.write(data)
     logger.debug(f"{uid}: Field {fieldname} blob written to {target_file}")
     relative_path = target_file.relative_to(content_export_path)
-    metadata._blob_files_.append(str(relative_path))
+    metadata._blob_files_.append(str(relative_path.as_posix()))
     return relative_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def export_path(tmp_path) -> Path:
 @pytest.fixture
 def paths_as_relative():
     def func(base_path: Path, paths: List[Path]) -> List[str]:
-        return [str(path.relative_to(base_path)) for path in paths]
+        return [str(path.relative_to(base_path).as_posix()) for path in paths]
 
     return func
 


### PR DESCRIPTION
As currently written, this package uses pathlib.Path to make operations platform independent. However, this poses a challenge when exporting from a Windows platform and then importing to a Posix platform. Posix platforms do not know how to read Windows paths and will end up trying to create None value Files, and a lot of other errors. This fix proposes to always output paths in the JSON data as Posix. We need to be careful to only do this when writing to the JSON data as we do still need platform specific Paths for a lot of operations - creating files, opening files, checking for existence of files/dirs, etc.

I'm cheating a bit in that I do not attempt to convert Posix paths to whatever platform we're importing on. The reason for this is that Windows already knows how to read Posix paths. Trying to convert it anyway would be tricky, because it's already working as is.