### PR TITLE
Fix export of remoteUrl to an internal page keeping the site url in the exported data

### DIFF
--- a/news/73.bugfix
+++ b/news/73.bugfix
@@ -1,0 +1,1 @@
+Fix export of remoteUrl to an internal page keeping the site url in the exported data. @ericof

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -42,6 +42,9 @@ def rewrite_site_root(item: dict, portal_url: str) -> dict:
         (f'"@parent": "{portal_url}/', '"@parent": "/'),
         (f'"@parent": "{portal_url}"', '"@parent": "/"'),
         (f'"url": "{portal_url}/', '"url": "/'),
+        (f'"url": "{portal_url}', '"url": "/'),
+        (f'"remoteUrl": "{portal_url}/', '"remoteUrl": "/'),
+        (f'"remoteUrl": "{portal_url}', '"remoteUrl": "/'),
     ]
     for pattern, replace in replacements:
         item_str = item_str.replace(pattern, replace)

--- a/tests/utils/test_utils_content_export_helpers.py
+++ b/tests/utils/test_utils_content_export_helpers.py
@@ -6,6 +6,9 @@ from plone.exportimport.utils.content import export_helpers
 import pytest
 
 
+PORTAL_URL = "http://nohost/plone"
+
+
 @pytest.fixture
 def exporter_config(portal, http_request) -> types.ExporterConfig:
     return types.ExporterConfig(
@@ -39,3 +42,25 @@ class TestUtilsContentExportHelpers:
         func = export_helpers.fix_language
         result = func(item, None, self.config)
         assert result["language"] == expected
+
+    @pytest.mark.parametrize(
+        "item,portal_url,expected",
+        [
+            [{"@id": f"{PORTAL_URL}/news"}, PORTAL_URL, {"@id": "/news"}],
+            [{"@id": f"{PORTAL_URL}/"}, PORTAL_URL, {"@id": "/"}],
+            [{"@id": f"{PORTAL_URL}"}, PORTAL_URL, {"@id": "/"}],
+            [{"@parent": f"{PORTAL_URL}/news"}, PORTAL_URL, {"@parent": "/news"}],
+            [{"@parent": f"{PORTAL_URL}/"}, PORTAL_URL, {"@parent": "/"}],
+            [{"@parent": f"{PORTAL_URL}"}, PORTAL_URL, {"@parent": "/"}],
+            [{"remoteUrl": f"{PORTAL_URL}/news"}, PORTAL_URL, {"remoteUrl": "/news"}],
+            [{"remoteUrl": f"{PORTAL_URL}/"}, PORTAL_URL, {"remoteUrl": "/"}],
+            [{"remoteUrl": f"{PORTAL_URL}"}, PORTAL_URL, {"remoteUrl": "/"}],
+            [{"url": f"{PORTAL_URL}/news"}, PORTAL_URL, {"url": "/news"}],
+            [{"url": f"{PORTAL_URL}/"}, PORTAL_URL, {"url": "/"}],
+            [{"url": f"{PORTAL_URL}"}, PORTAL_URL, {"url": "/"}],
+        ],
+    )
+    def test_rewrite_site_root(self, item: dict, portal_url: str, expected: dict):
+        func = export_helpers.rewrite_site_root
+        result = func(item, portal_url)
+        assert result == expected


### PR DESCRIPTION
Closes #73

- [X] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [X] I verified there aren't any other open pull requests for the same change.
- [X] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [X] I successfully ran code quality checks on my changes locally.
- [X] I successfully ran tests on my changes locally.
- [X] If needed, I added new tests for my changes.
- [X] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [X] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.
