### PR TITLE
Typo

### DIFF
--- a/src/plone/exportimport/interfaces.py
+++ b/src/plone/exportimport/interfaces.py
@@ -20,4 +20,4 @@ class INamedExporter(Interface):
 
 
 class INamedImporter(Interface):
-    """Component to export content from a Plone Site."""
+    """Component to import content from a Plone Site."""


### PR DESCRIPTION
@ericof are `IExporter` and `INamedExporter` meant to have the same docstring as well? And likewise for their importer counterparts? :)