### PR TITLE
Config with default template 2.8.1.dev0 plone.meta

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 version: 2
 updates:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -20,14 +20,14 @@ on:
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@2.x
-  test:
-    uses: plone/meta/.github/workflows/test.yml@2.x
   coverage:
     uses: plone/meta/.github/workflows/coverage.yml@2.x
   dependencies:
     uses: plone/meta/.github/workflows/dependencies.yml@2.x
   release_ready:
     uses: plone/meta/.github/workflows/release_ready.yml@2.x
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@2.x
 
 ##
 # To modify the list of default jobs being created add in .meta.toml:

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,10 +1,11 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -19,7 +20,7 @@ jobs:
         - ["ubuntu", "ubuntu-latest"]
         config:
         # [Python version, visual name, tox env]
-        - ["3.13", "6.2 on py3.13", "py313-plone62"]
+        - ["3.14", "6.2 on py3.14", "py314-plone62"]
         - ["3.10", "6.2 on py3.10", "py310-plone62"]
 
     runs-on: ${{ matrix.os[1] }}
@@ -29,11 +30,15 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v8.1.0
       with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
         python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -42,25 +47,13 @@ jobs:
 #  _your own configuration lines_
 #  """
 ##
-    - name: Pip cache
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
     - name: Initialize tox
       # the bash one-liner below does not work on Windows
       if: contains(matrix.os, 'ubuntu')
       run: |
-        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
     - name: Test
-      run: tox -e ${{ matrix.config[2] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
 
 
 ##

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info
@@ -47,7 +47,6 @@ local.cfg
 /sources/
 /venv/
 .installed.txt
-/.mxdev_cache/
 
 coverage.xml
 

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.2.2"
+commit-id = "2.8.1.dev0"
 
 [pyproject]
 codespell_skip = "*.min.js"

--- a/.meta.toml
+++ b/.meta.toml
@@ -20,15 +20,6 @@ use_mxdev = true
 test_deps_additional = ""
 test_matrix = {"6.2" = ["*"]}
 
-[github]
-jobs = [
-    "qa",
-    "test",
-    "coverage",
-    "dependencies",
-    "release_ready",
-    ]
-
 [gitignore]
 extra_lines = """
 coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,20 +7,20 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.1
+    rev: 4.0.0
     hooks:
     -   id: zpretty
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -62,16 +62,16 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.23.0"
+    rev: "0.24.2"
     hooks:
     -   id: check-python-versions
-        args: ['--only', 'setup.py,pyproject.toml']
+        args: ['--only', 'setup.py,tox.ini']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 

--- a/news/+d6efc394.internal.md
+++ b/news/+d6efc394.internal.md
@@ -1,0 +1,1 @@
+Remove Python 3.8/3.9 compatibility imports for type hints.  @mauritsvanrees

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,1 @@
+Update configuration files @plone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
+
+
 
 [tool.towncrier]
 directory = "news/"
@@ -14,32 +16,32 @@ underlines = ["", "", ""]
 
 [[tool.towncrier.type]]
 directory = "breaking"
-name = "Breaking changes:"
+name = "Breaking changes"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "feature"
-name = "New features:"
+name = "New features"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name = "Bug fixes:"
+name = "Bug fixes"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "Internal:"
+name = "Internal"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "documentation"
-name = "Documentation:"
+name = "Documentation"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "tests"
-name = "Tests:"
+name = "Tests"
 showcontent = true
 
 ##
@@ -62,7 +64,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from setuptools import setup
 
-
 long_description = f"""
 {Path("README.md").read_text()}\n
 {Path("CHANGES.md").read_text()}\n
@@ -27,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     python_requires=">=3.10",
     keywords="Plone CMF Python Zope CMS",

--- a/src/plone/exportimport/__init__.py
+++ b/src/plone/exportimport/__init__.py
@@ -2,7 +2,6 @@
 
 import logging
 
-
 PACKAGE_NAME = "plone.exportimport"
 
 logger = logging.getLogger(PACKAGE_NAME)

--- a/src/plone/exportimport/cli/__init__.py
+++ b/src/plone/exportimport/cli/__init__.py
@@ -9,7 +9,6 @@ import argparse
 import sys
 import transaction
 
-
 CLI_SPEC = {
     "exporter": {
         "description": "Export Plone Site content",

--- a/src/plone/exportimport/exporters/__init__.py
+++ b/src/plone/exportimport/exporters/__init__.py
@@ -6,9 +6,6 @@ from plone.exportimport import logger
 from plone.exportimport import PACKAGE_NAME
 from Products.CMFPlone.Portal import PloneSite
 from tempfile import mkdtemp
-from typing import Dict
-from typing import List
-from typing import Optional
 from zope.component import getAdapter
 from zope.component import hooks
 from zope.component import queryAdapter
@@ -27,7 +24,7 @@ EXPORTER_NAMES = [
 ]
 
 
-ExporterMapping = Dict[str, BaseExporter]
+ExporterMapping = dict[str, BaseExporter]
 
 
 @implementer(interfaces.IExporter)
@@ -52,7 +49,7 @@ class Exporter:
         return exporters
 
     @staticmethod
-    def _prepare_path(path: Optional[Path] = None) -> Path:
+    def _prepare_path(path: Path | None = None) -> Path:
         """Return a valid path to use for the export.
 
         If base_path is not given, create a temporary directory to export
@@ -64,11 +61,11 @@ class Exporter:
         return path
 
     def export_site(
-        self, path: Optional[Path] = None, options: Optional[argparse.Namespace] = None
-    ) -> List[Path]:
+        self, path: Path | None = None, options: argparse.Namespace | None = None
+    ) -> list[Path]:
         """Export the given site to the filesystem."""
         path = self._prepare_path(path)
-        paths: List[Path] = [path]
+        paths: list[Path] = [path]
         with hooks.site(self.site):
             for exporter_name, exporter in self.exporters.items():
                 logger.debug(f"Exporting {self.site} with {exporter_name} to {path}")

--- a/src/plone/exportimport/exporters/__init__.py
+++ b/src/plone/exportimport/exporters/__init__.py
@@ -16,7 +16,6 @@ from zope.interface import implementer
 
 import argparse
 
-
 EXPORTER_NAMES = [
     "plone.exporter.content",
     "plone.exporter.principals",

--- a/src/plone/exportimport/exporters/base.py
+++ b/src/plone/exportimport/exporters/base.py
@@ -1,12 +1,10 @@
+from collections.abc import Callable
 from pathlib import Path
 from plone.exportimport import types
 from plone.exportimport.utils import content as utils
 from plone.exportimport.utils import path as path_utils
 from Products.CMFPlone.Portal import PloneSite
 from typing import Any
-from typing import Callable
-from typing import List
-from typing import Optional
 from zope.globalrequest import getRequest
 
 import argparse
@@ -18,9 +16,9 @@ class BaseExporter:
     base_path: Path
     errors: list = None
     request: types.HTTPRequest = None
-    data_hooks: List[Callable] = None
-    obj_hooks: List[Callable] = None
-    options: Optional[argparse.Namespace] = None
+    data_hooks: list[Callable] = None
+    obj_hooks: list[Callable] = None
+    options: argparse.Namespace | None = None
 
     def __init__(
         self,
@@ -58,17 +56,17 @@ class BaseExporter:
             fh.write("\n")
         return filepath
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize objects."""
         return []
 
     def export_data(
         self,
         base_path: Path,
-        data_hooks: List[Callable] = None,
-        obj_hooks: List[Callable] = None,
-        options: Optional[argparse.Namespace] = None,
-    ) -> List[Path]:
+        data_hooks: list[Callable] = None,
+        obj_hooks: list[Callable] = None,
+        options: argparse.Namespace | None = None,
+    ) -> list[Path]:
         """Write data to filesystem."""
         if not base_path.exists():
             base_path.mkdir(parents=True)

--- a/src/plone/exportimport/exporters/content.py
+++ b/src/plone/exportimport/exporters/content.py
@@ -1,4 +1,6 @@
 from .base import BaseExporter
+from collections.abc import Callable
+from collections.abc import Generator
 from pathlib import Path
 from plone import api
 from plone.base.interfaces import IPloneSiteRoot
@@ -10,10 +12,6 @@ from plone.exportimport import types
 from plone.exportimport.interfaces import IExportImportRequestMarker
 from plone.exportimport.utils import content as content_utils
 from plone.exportimport.utils import request_provides
-from typing import Callable
-from typing import Generator
-from typing import List
-from typing import Optional
 from zope.interface import implementer
 
 import argparse
@@ -132,7 +130,7 @@ class ContentExporter(BaseExporter):
         filepath = self.base_path / "__metadata__.json"
         return self._dump(metadata, filepath)
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize contents and dump them to disk."""
         paths = []
         with request_provides(self.request, IExportImportRequestMarker):
@@ -147,11 +145,11 @@ class ContentExporter(BaseExporter):
     def export_data(
         self,
         base_path: Path,
-        data_hooks: List[Callable] = None,
-        obj_hooks: List[Callable] = None,
-        query: Optional[dict] = None,
-        options: Optional[argparse.Namespace] = None,
-    ) -> List[Path]:
+        data_hooks: list[Callable] = None,
+        obj_hooks: list[Callable] = None,
+        query: dict | None = None,
+        options: argparse.Namespace | None = None,
+    ) -> list[Path]:
         # Content in a subpath of base_path
         base_path = base_path / self.name
         query = query if query else {}

--- a/src/plone/exportimport/exporters/discussions.py
+++ b/src/plone/exportimport/exporters/discussions.py
@@ -2,7 +2,6 @@ from .base import BaseExporter
 from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
-from typing import List
 from zope.interface import implementer
 
 try:
@@ -17,7 +16,7 @@ else:
 class DiscussionsExporter(BaseExporter):
     name: str = "discussions"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         if not HAS_DISCUSSION:
             logger.debug("- Discussions: Skipping (plone.app.discussion not installed)")

--- a/src/plone/exportimport/exporters/discussions.py
+++ b/src/plone/exportimport/exporters/discussions.py
@@ -5,7 +5,6 @@ from plone.exportimport import logger
 from typing import List
 from zope.interface import implementer
 
-
 try:
     import plone.app.discussion  # noqa
 except ImportError:

--- a/src/plone/exportimport/exporters/portlets.py
+++ b/src/plone/exportimport/exporters/portlets.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from plone.exportimport.utils import portlets as utils
-from typing import List
 from zope.interface import implementer
 
 
@@ -11,7 +10,7 @@ from zope.interface import implementer
 class PortletsExporter(BaseExporter):
     name: str = "portlets"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         portlets = utils.get_portlets()
         filepath = self._dump(portlets, self.filepath)

--- a/src/plone/exportimport/exporters/principals.py
+++ b/src/plone/exportimport/exporters/principals.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from plone.exportimport.utils import principals as principals_utils
-from typing import List
 from zope.interface import implementer
 
 
@@ -11,7 +10,7 @@ from zope.interface import implementer
 class PrincipalsExporter(BaseExporter):
     name: str = "principals"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         data = {
             "groups": principals_utils.export_groups(),

--- a/src/plone/exportimport/exporters/redirects.py
+++ b/src/plone/exportimport/exporters/redirects.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from plone.exportimport.utils import redirects as utils
-from typing import List
 from zope.interface import implementer
 
 
@@ -11,7 +10,7 @@ from zope.interface import implementer
 class RedirectsExporter(BaseExporter):
     name: str = "redirects"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         redirects = utils.get_redirects()
         filepath = self._dump(redirects, self.filepath)

--- a/src/plone/exportimport/exporters/relations.py
+++ b/src/plone/exportimport/exporters/relations.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from plone.exportimport.utils import relations as utils
-from typing import List
 from zope.interface import implementer
 
 
@@ -11,7 +10,7 @@ from zope.interface import implementer
 class RelationsExporter(BaseExporter):
     name: str = "relations"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         relations = utils.get_relations()
         filepath = self._dump(relations, self.filepath)

--- a/src/plone/exportimport/exporters/translations.py
+++ b/src/plone/exportimport/exporters/translations.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from plone.exportimport.utils import translations as utils
-from typing import List
 from zope.interface import implementer
 
 
@@ -11,7 +10,7 @@ from zope.interface import implementer
 class TranslationsExporter(BaseExporter):
     name: str = "translations"
 
-    def dump(self) -> List[Path]:
+    def dump(self) -> list[Path]:
         """Serialize object and dump it to disk."""
         translations = utils.get_translations()
         filepath = self._dump(translations, self.filepath)

--- a/src/plone/exportimport/importers/__init__.py
+++ b/src/plone/exportimport/importers/__init__.py
@@ -4,9 +4,6 @@ from plone import api
 from plone.exportimport import interfaces
 from plone.exportimport import logger
 from Products.CMFPlone.Portal import PloneSite
-from typing import Dict
-from typing import List
-from typing import Optional
 from zope.component import getAdapter
 from zope.component import hooks
 from zope.component import queryAdapter
@@ -23,7 +20,7 @@ IMPORTER_NAMES = [
     "plone.importer.final",
 ]
 
-ImporterMapping = Dict[str, BaseImporter]
+ImporterMapping = dict[str, BaseImporter]
 
 
 @implementer(interfaces.IImporter)
@@ -47,7 +44,7 @@ class Importer:
                 importers[importer_name] = importer
         return importers
 
-    def import_site(self, path: Path) -> List[str]:
+    def import_site(self, path: Path) -> list[str]:
         """Import the given site from the filesystem."""
         report = []
         with hooks.site(self.site):
@@ -59,7 +56,7 @@ class Importer:
         return report
 
 
-def get_importer(site: Optional[PloneSite] = None) -> Importer:
+def get_importer(site: PloneSite | None = None) -> Importer:
     """Get the importer."""
     if site is None:
         site = api.portal.get()

--- a/src/plone/exportimport/importers/__init__.py
+++ b/src/plone/exportimport/importers/__init__.py
@@ -12,7 +12,6 @@ from zope.component import hooks
 from zope.component import queryAdapter
 from zope.interface import implementer
 
-
 IMPORTER_NAMES = [
     "plone.importer.principals",
     "plone.importer.content",

--- a/src/plone/exportimport/importers/base.py
+++ b/src/plone/exportimport/importers/base.py
@@ -1,13 +1,10 @@
+from collections.abc import Callable
 from pathlib import Path
 from plone.exportimport import settings
 from plone.exportimport import types
 from plone.exportimport.utils import content as utils
 from Products.CMFPlone.Portal import PloneSite
 from typing import Any
-from typing import Callable
-from typing import List
-from typing import Optional
-from typing import Union
 from zope.globalrequest import getRequest
 
 import json
@@ -18,11 +15,11 @@ class BaseImporter:
     name: str
     base_path: Path
     site: PloneSite
-    errors: Optional[list] = None
-    request: Optional[types.HTTPRequest] = None
-    data_hooks: Optional[List[Callable]] = None
-    pre_deserialize_hooks: Optional[List[Callable]] = None
-    obj_hooks: Optional[List[Callable]] = None
+    errors: list | None = None
+    request: types.HTTPRequest | None = None
+    data_hooks: list[Callable] | None = None
+    pre_deserialize_hooks: list[Callable] | None = None
+    obj_hooks: list[Callable] | None = None
     intermediate_commits: bool = not settings.IMPORTER_COMMIT_DISABLE
     savepoint_after: int = settings.IMPORTER_SAVEPOINT_AFTER
     commit_after: int = settings.IMPORTER_COMMIT_AFTER
@@ -44,7 +41,7 @@ class BaseImporter:
         """Deserializer for object."""
         return utils.get_deserializer(obj, self.request)
 
-    def _read(self, filepath: Optional[Path] = None) -> Union[dict, list, None]:
+    def _read(self, filepath: Path | None = None) -> dict | list | None:
         """Read data from file."""
         filepath = filepath if filepath else self.filepath
         if filepath.exists() and filepath.is_file():
@@ -72,9 +69,9 @@ class BaseImporter:
     def import_data(
         self,
         base_path: Path,
-        data_hooks: Optional[List[Callable]] = None,
-        pre_deserialize_hooks: Optional[List[Callable]] = None,
-        obj_hooks: Optional[List[Callable]] = None,
+        data_hooks: list[Callable] | None = None,
+        pre_deserialize_hooks: list[Callable] | None = None,
+        obj_hooks: list[Callable] | None = None,
     ) -> str:
         """Import data into a Plone site."""
         if not base_path.exists():
@@ -99,9 +96,9 @@ class BaseDatalessImporter(BaseImporter):
     def import_data(
         self,
         base_path: Path,
-        data_hooks: Optional[List[Callable]] = None,
-        pre_deserialize_hooks: Optional[List[Callable]] = None,
-        obj_hooks: Optional[List[Callable]] = None,
+        data_hooks: list[Callable] | None = None,
+        pre_deserialize_hooks: list[Callable] | None = None,
+        obj_hooks: list[Callable] | None = None,
     ) -> str:
         """Import data into a Plone site.
 

--- a/src/plone/exportimport/importers/content.py
+++ b/src/plone/exportimport/importers/content.py
@@ -1,4 +1,6 @@
 from .base import BaseImporter
+from collections.abc import Callable
+from collections.abc import Generator
 from pathlib import Path
 from plone.dexterity.content import DexterityContent
 from plone.exportimport import logger
@@ -7,18 +9,14 @@ from plone.exportimport import types
 from plone.exportimport.interfaces import IExportImportRequestMarker
 from plone.exportimport.utils import content as content_utils
 from plone.exportimport.utils import request_provides
-from typing import Callable
-from typing import Generator
-from typing import List
-from typing import Optional
 
 import json
 
 
 class ContentImporter(BaseImporter):
     name: str = "content"
-    metadata: Optional[types.ExportImportMetadata] = None
-    languages: Optional[types.PortalLanguages] = None
+    metadata: types.ExportImportMetadata | None = None
+    languages: types.PortalLanguages | None = None
     dropped: set[str] = set()
 
     def _cleanse_ordering(self, raw_data: dict[str, int]) -> dict[str, int]:
@@ -64,7 +62,7 @@ class ContentImporter(BaseImporter):
             )
         return obj
 
-    def construct(self, item: dict) -> Optional[DexterityContent]:
+    def construct(self, item: dict) -> DexterityContent | None:
         """Serialize object."""
         item_path = item["@id"]
         config = types.ImporterConfig(
@@ -188,9 +186,9 @@ class ContentImporter(BaseImporter):
     def import_data(
         self,
         base_path: Path,
-        data_hooks: Optional[List[Callable]] = None,
-        pre_deserialize_hooks: Optional[List[Callable]] = None,
-        obj_hooks: Optional[List[Callable]] = None,
+        data_hooks: list[Callable] | None = None,
+        pre_deserialize_hooks: list[Callable] | None = None,
+        obj_hooks: list[Callable] | None = None,
     ) -> str:
         """Import content into a site."""
         base_path = base_path / self.name

--- a/src/plone/exportimport/importers/principals.py
+++ b/src/plone/exportimport/importers/principals.py
@@ -1,19 +1,18 @@
 from .base import BaseImporter
 from plone.exportimport import logger
 from plone.exportimport.utils import principals as principals_utils
-from typing import List
 
 
 class PrincipalsImporter(BaseImporter):
     name: str = "principals"
 
-    def _import_groups(self, groups=List[dict]) -> int:
+    def _import_groups(self, groups=list[dict]) -> int:
         logger.debug(f"- Principals: Read {len(groups)} groups from {self.filepath}")
         total = len(principals_utils.import_groups(groups))
         logger.debug(f"- Principals: Imported {total} groups")
         return total
 
-    def _import_members(self, members=List[dict]) -> int:
+    def _import_members(self, members=list[dict]) -> int:
         logger.debug(f"- Principals: Read {len(members)} groups from {self.filepath}")
         total = len(principals_utils.import_members(members))
         logger.debug(f"- Principals: Imported {total} members")

--- a/src/plone/exportimport/serializers/fields.py
+++ b/src/plone/exportimport/serializers/fields.py
@@ -14,7 +14,6 @@ from zope.schema.interfaces import IVocabularyTokenized
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/plone/exportimport/settings.py
+++ b/src/plone/exportimport/settings.py
@@ -2,7 +2,6 @@ from typing import Tuple
 
 import os
 
-
 SITE_ROOT_UID = "plone_site_root"
 
 EXPORT_CONTENT_FILEPATH = "{UID}/data.json"

--- a/src/plone/exportimport/settings.py
+++ b/src/plone/exportimport/settings.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import os
 
 SITE_ROOT_UID = "plone_site_root"
@@ -16,8 +14,8 @@ SERIALIZER_CONSTRAINS_KEY = "exportimport.constrains"
 
 PLACEHOLDERS_LANGUAGE = "##DEFAULT##"
 
-AUTO_GROUPS: Tuple[str] = ("AuthenticatedUsers",)
-AUTO_ROLES: Tuple[str] = ("Authenticated",)
+AUTO_GROUPS: tuple[str] = ("AuthenticatedUsers",)
+AUTO_ROLES: tuple[str] = ("Authenticated",)
 
 # Savepoint and commit changes
 IMPORTER_COMMIT_DISABLE: bool = bool(os.environ.get("IMPORTER_COMMIT_DISABLE", 0))

--- a/src/plone/exportimport/types.py
+++ b/src/plone/exportimport/types.py
@@ -1,10 +1,8 @@
+from collections.abc import Callable
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
 from Products.CMFPlone.Portal import PloneSite
-from typing import Callable
-from typing import Dict
-from typing import List
 from typing import Protocol
 from ZPublisher.HTTPRequest import HTTPRequest
 
@@ -14,7 +12,7 @@ class PortalLanguages:
     """Languages configuration in a portal."""
 
     default: str
-    available: List[str]
+    available: list[str]
 
 
 @dataclass
@@ -28,9 +26,9 @@ class ExportImportMetadata:
     constraints: dict = field(default_factory=dict)
     relations: list = field(default_factory=list)
     __version__: str = "1.0.0"
-    _data_files_: List[str] = field(default_factory=list)
-    _blob_files_: List[str] = field(default_factory=list)
-    _all_: Dict[str, str] = field(default_factory=dict)
+    _data_files_: list[str] = field(default_factory=list)
+    _blob_files_: list[str] = field(default_factory=list)
+    _all_: dict[str, str] = field(default_factory=dict)
 
     def export(self) -> dict:
         dump = asdict(self)

--- a/src/plone/exportimport/utils/cli.py
+++ b/src/plone/exportimport/utils/cli.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from plone.restapi.interfaces import IPloneRestapiLayer
 from Products.CMFPlone.Portal import PloneSite
 from Testing.makerequest import makerequest
-from typing import Optional
 from Zope2.Startup.run import make_wsgi_app
 from zope.globalrequest import setRequest
 from zope.interface import directlyProvidedBy
@@ -15,7 +14,7 @@ import sys
 import Zope2
 
 
-def _process_path(path: str) -> Optional[Path]:
+def _process_path(path: str) -> Path | None:
     """Process path."""
     path = Path(path).resolve()
     return path if path.exists() else None
@@ -60,7 +59,7 @@ def get_app(zopeconf: Path):
     return app
 
 
-def get_site(app, site_id: str, logger: logging.Logger) -> Optional[PloneSite]:
+def get_site(app, site_id: str, logger: logging.Logger) -> PloneSite | None:
     """Get Plone Site"""
     site = app.unrestrictedTraverse(site_id, None)
     if not site:

--- a/src/plone/exportimport/utils/content/blocks.py
+++ b/src/plone/exportimport/utils/content/blocks.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def _fix_image_paths(data: list) -> List[dict]:
+def _fix_image_paths(data: list) -> list[dict]:
     """Rewrite image urls to use the scale name.
 
     This is not ideal in terms of performance, but

--- a/src/plone/exportimport/utils/content/core.py
+++ b/src/plone/exportimport/utils/content/core.py
@@ -10,8 +10,6 @@ from plone.exportimport import settings
 from plone.exportimport import types
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.Portal import PloneSite
-from typing import List
-from typing import Optional
 from zope.interface.interface import InterfaceClass
 from zope.schema import getFields
 
@@ -26,7 +24,7 @@ def is_site_root(obj: DexterityContent) -> bool:
     return IPloneSiteRoot.providedBy(obj)
 
 
-def get_uid(obj: DexterityContent) -> Optional[str]:
+def get_uid(obj: DexterityContent) -> str | None:
     """Return the uid for the given object.
 
     If obj is a Plone Site Root, return a constant
@@ -44,7 +42,7 @@ def get_obj_path(obj: DexterityContent, relative_to_site_root: bool = False) -> 
     return obj_path
 
 
-def object_from_uid(uid: str) -> Optional[DexterityContent]:
+def object_from_uid(uid: str) -> DexterityContent | None:
     """Return an object for a given uid."""
     if uid == settings.SITE_ROOT_UID:
         return api.portal.get()
@@ -53,7 +51,7 @@ def object_from_uid(uid: str) -> Optional[DexterityContent]:
     return brains[0].getObject() if brains else None
 
 
-def object_from_uid_or_path(uid: str, path: str = "") -> Optional[DexterityContent]:
+def object_from_uid_or_path(uid: str, path: str = "") -> DexterityContent | None:
     """Return an object for a given uid or given path."""
     obj = None
     if path:
@@ -76,14 +74,14 @@ def get_portal_languages() -> types.PortalLanguages:
     return types.PortalLanguages(default, available)
 
 
-def get_parent_ordered(obj: DexterityContent) -> Optional[OrderSupport]:
+def get_parent_ordered(obj: DexterityContent) -> OrderSupport | None:
     """Get the OrderedContainer implementation of the parent of the given obj."""
     parent = aq_parent(obj)
     return IOrderedContainer(parent, None) if is_folderish(parent) else None
 
 
 def get_all_fields(
-    obj: DexterityContent, filter: Optional[List[type[InterfaceClass]]] = None
+    obj: DexterityContent, filter: list[type[InterfaceClass]] | None = None
 ) -> dict:
     """Return a dictionary with all fields defined for the given object."""
     fields = {}

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -5,6 +5,7 @@ from .core import is_folderish
 from .revisions import revision_history
 from Acquisition import aq_base
 from Acquisition import aq_parent
+from collections.abc import Callable
 from plone import api
 from plone.base.interfaces.constrains import ENABLED
 from plone.base.interfaces.constrains import ISelectableConstrainTypes
@@ -16,9 +17,6 @@ from plone.exportimport.utils.relations import relation_fields_for_content
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFEditions.ZVCStorageTool import ShadowHistory
-from typing import Callable
-from typing import List
-from typing import Optional
 from zope.component import getMultiAdapter
 
 import json
@@ -237,7 +235,7 @@ def add_revisions_history(obj: DexterityContent, config: types.ExporterConfig) -
 
 def default_page_info(
     obj: DexterityContent, config: types.ExporterConfig
-) -> Optional[dict]:
+) -> dict | None:
     """Default page for a given obj.
 
     We use a simplified method to only get index_html
@@ -268,14 +266,12 @@ def default_page_info(
 
 def get_position_in_parent(
     obj: DexterityContent, config: types.ExporterConfig
-) -> Optional[int]:
+) -> int | None:
     ordered = get_parent_ordered(obj)
     return ordered.getObjectPosition(obj.getId()) if ordered else None
 
 
-def get_local_roles(
-    obj: DexterityContent, config: types.ExporterConfig
-) -> Optional[dict]:
+def get_local_roles(obj: DexterityContent, config: types.ExporterConfig) -> dict | None:
     item = {}
     local_roles = None
     block = None
@@ -292,7 +288,7 @@ def get_local_roles(
     return item if item else None
 
 
-def fixers() -> List[types.ExportImportHelper]:
+def fixers() -> list[types.ExportImportHelper]:
     fixers = []
     funcs = [
         fix_relation_fields,
@@ -314,7 +310,7 @@ def fixers() -> List[types.ExportImportHelper]:
     return fixers
 
 
-def enrichers(include_revisions: bool = False) -> List[types.ExportImportHelper]:
+def enrichers(include_revisions: bool = False) -> list[types.ExportImportHelper]:
     enrichers = []
     funcs = [
         add_constraints_info,
@@ -335,7 +331,7 @@ def enrichers(include_revisions: bool = False) -> List[types.ExportImportHelper]
     return enrichers
 
 
-def cleaners() -> List[types.ExportImportHelper]:
+def cleaners() -> list[types.ExportImportHelper]:
     cleaners = []
     funcs = [
         cleanup_export_data,
@@ -351,7 +347,7 @@ def cleaners() -> List[types.ExportImportHelper]:
     return cleaners
 
 
-def metadata_helpers() -> List[types.ExportImportHelper]:
+def metadata_helpers() -> list[types.ExportImportHelper]:
     helpers = []
     funcs = [
         (default_page_info, "default_page"),

--- a/src/plone/exportimport/utils/content/export_helpers.py
+++ b/src/plone/exportimport/utils/content/export_helpers.py
@@ -23,7 +23,6 @@ from zope.component import getMultiAdapter
 
 import json
 
-
 try:
     from plone.app.discussion.interfaces import IConversation
 except ImportError:

--- a/src/plone/exportimport/utils/content/import_helpers.py
+++ b/src/plone/exportimport/utils/content/import_helpers.py
@@ -4,6 +4,7 @@ from .core import object_from_uid_or_path
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from collections.abc import Callable
 from pathlib import PurePosixPath
 from Persistence import PersistentMapping
 from plone import api
@@ -23,10 +24,6 @@ from plone.restapi.interfaces import IDeserializeFromJson
 from Products.CMFEditions.CopyModifyMergeRepositoryTool import (
     CopyModifyMergeRepositoryTool,
 )
-from typing import Callable
-from typing import List
-from typing import Optional
-from typing import Tuple
 from unittest.mock import patch
 from urllib.parse import unquote
 from zExceptions import NotFound
@@ -37,7 +34,7 @@ def get_deserializer(data: dict, request) -> Callable:
     return getMultiAdapter((data, request), IDeserializeFromJson)
 
 
-def get_parent_from_item(data: dict) -> Optional[DexterityContent]:
+def get_parent_from_item(data: dict) -> DexterityContent | None:
     parent_path = str(PurePosixPath(data["@id"]).parent)
     if data.get("@type") == "Plone Site":
         portal = aq_inner(api.portal.get())
@@ -94,7 +91,7 @@ def process_root_uid(item: dict, config: types.ImporterConfig) -> dict:
     return item
 
 
-def processors() -> List[types.ExportImportHelper]:
+def processors() -> list[types.ExportImportHelper]:
     """Return processors to be used by the importer."""
     processors = []
     funcs = [
@@ -119,7 +116,7 @@ def _mock_isVersionable(*args, **kwargs):
 
 def get_obj_instance(
     item: dict, config: types.ImporterConfig
-) -> Optional[DexterityContent]:
+) -> DexterityContent | None:
     # Get container
     container = get_parent_from_item(item)
     if not container:
@@ -228,7 +225,7 @@ def reset_modification_date(obj: DexterityContent) -> DexterityContent:
     return obj
 
 
-def updaters() -> List[types.ExportImportHelper]:
+def updaters() -> list[types.ExportImportHelper]:
     """Return updaters to be used by the importer."""
     updaters = []
     funcs = [
@@ -353,9 +350,9 @@ def set_local_permissions(uid: str, value: dict, path: str = "") -> bool:
     return _set_local_permissions(obj, value)
 
 
-def metadata_setters() -> List[types.ImporterSetter]:
+def metadata_setters() -> list[types.ImporterSetter]:
     helpers = []
-    funcs: List[Tuple[types.ImporterSetterFunction, str]] = [
+    funcs: list[tuple[types.ImporterSetterFunction, str]] = [
         (set_default_page, "default_page"),
         (set_ordering, "ordering"),
         (set_local_roles, "local_roles"),
@@ -374,7 +371,7 @@ def metadata_setters() -> List[types.ImporterSetter]:
     return helpers
 
 
-def recatalog_uids(uids: List[str], idxs: List[str]):
+def recatalog_uids(uids: list[str], idxs: list[str]):
     logger.info(f"Reindexing catalog indexes {', '.join(idxs)} for {len(uids)} objects")
     for uid in uids:
         obj = object_from_uid_or_path(uid, "")
@@ -383,7 +380,7 @@ def recatalog_uids(uids: List[str], idxs: List[str]):
         obj.reindexObject(idxs)
 
 
-def final_updaters() -> List[types.ExportImportHelper]:
+def final_updaters() -> list[types.ExportImportHelper]:
     updaters = []
     funcs = [
         reset_modification_date,

--- a/src/plone/exportimport/utils/content/revisions.py
+++ b/src/plone/exportimport/utils/content/revisions.py
@@ -1,7 +1,6 @@
 from plone import api
 from plone.dexterity.content import DexterityContent
 from plone.exportimport.utils.principals.members import get_history_user_info
-from typing import List
 
 
 def _format_as_history(vdata: dict, version_id: int) -> dict:
@@ -23,7 +22,7 @@ def _format_as_history(vdata: dict, version_id: int) -> dict:
     return info
 
 
-def revision_history(obj: DexterityContent) -> List[dict]:
+def revision_history(obj: DexterityContent) -> list[dict]:
     """Return revision history for an object."""
     raw_history = []
     results = []

--- a/src/plone/exportimport/utils/dates.py
+++ b/src/plone/exportimport/utils/dates.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 from DateTime import DateTime
 from dateutil import parser
-from typing import Optional
 
 
-def parse_datetime(value: str) -> Optional[datetime]:
+def parse_datetime(value: str) -> datetime | None:
     """Parse a value and return a datetime instance."""
     if value:
         try:
@@ -14,7 +13,7 @@ def parse_datetime(value: str) -> Optional[datetime]:
         return result
 
 
-def parse_date(value: str) -> Optional[DateTime]:
+def parse_date(value: str) -> DateTime | None:
     """Parse a value and return a DateTime instance."""
     if value:
         parsed = parse_datetime(value)

--- a/src/plone/exportimport/utils/discussions.py
+++ b/src/plone/exportimport/utils/discussions.py
@@ -20,7 +20,6 @@ from typing import Union
 from zope.annotation.interfaces import IAnnotations
 from zope.globalrequest import getRequest
 
-
 DISCUSSION_ANNOTATION_KEY = "plone.app.discussion:conversation"
 
 

--- a/src/plone/exportimport/utils/discussions.py
+++ b/src/plone/exportimport/utils/discussions.py
@@ -13,17 +13,13 @@ from plone.exportimport import logger
 from Products.CMFCore.interfaces import IContentish
 from Products.PortalTransforms.TransformEngine import TransformTool
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Tuple
-from typing import Union
 from zope.annotation.interfaces import IAnnotations
 from zope.globalrequest import getRequest
 
 DISCUSSION_ANNOTATION_KEY = "plone.app.discussion:conversation"
 
 
-def _get_all_content_support_conversation() -> List[Tuple[str, Conversation]]:
+def _get_all_content_support_conversation() -> list[tuple[str, Conversation]]:
     catalog = api.portal.get_tool("portal_catalog")
     results = []
     brains = catalog.unrestrictedSearchResults(
@@ -38,7 +34,7 @@ def _get_all_content_support_conversation() -> List[Tuple[str, Conversation]]:
     return results
 
 
-def get_discussions() -> Dict[str, Any]:
+def get_discussions() -> dict[str, Any]:
     """Get all discussions."""
     request = getRequest()
     portal_url = api.portal.get().absolute_url()
@@ -56,7 +52,7 @@ def get_discussions() -> Dict[str, Any]:
 
 
 def _extract_text(
-    text: Union[dict, str], target_mime_type: str, transforms: TransformTool
+    text: dict | str, target_mime_type: str, transforms: TransformTool
 ) -> str:
     """Transform text data."""
     result = text
@@ -86,7 +82,7 @@ def _create_comment(item: dict, text: str) -> Comment:
     return comment
 
 
-def set_discussions(data: dict) -> List[dict]:
+def set_discussions(data: dict) -> list[dict]:
     """Set all discussions."""
     results = []
     transforms = api.portal.get_tool("portal_transforms")

--- a/src/plone/exportimport/utils/portlets.py
+++ b/src/plone/exportimport/utils/portlets.py
@@ -14,9 +14,6 @@ from plone.portlets.interfaces import IPortletAssignmentSettings
 from plone.portlets.interfaces import IPortletManager
 from plone.restapi.interfaces import IFieldDeserializer
 from plone.restapi.serializer.converters import json_compatible
-from typing import List
-from typing import Optional
-from typing import Union
 from z3c.relationfield import RelationValue
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
@@ -31,8 +28,8 @@ import warnings
 
 
 def portlets_in_context(
-    context: DexterityContent, uid: Optional[str] = None
-) -> Union[dict, None]:
+    context: DexterityContent, uid: str | None = None
+) -> dict | None:
     """Collect portlet registrations in a context."""
     result = {}
     uid = uid if uid else api.content.get_uuid(context, None)
@@ -55,7 +52,7 @@ def portlets_in_context(
     return result
 
 
-def get_portlets() -> List[dict]:
+def get_portlets() -> list[dict]:
     """Return a list of all portlet assignments on the site."""
     results = []
     portal = api.portal.get()
@@ -129,7 +126,7 @@ def export_local_portlets(obj: DexterityContent) -> dict:
     return items
 
 
-def export_blocked_portlets(obj: DexterityContent) -> List[dict]:
+def export_blocked_portlets(obj: DexterityContent) -> list[dict]:
     """Export portlets blocked for one content object."""
     results = []
     for manager_name, manager in getUtilitiesFor(IPortletManager):

--- a/src/plone/exportimport/utils/principals/groups.py
+++ b/src/plone/exportimport/utils/principals/groups.py
@@ -3,10 +3,9 @@ from .helpers import get_roles_for_group
 from plone import api
 from plone.restapi.serializer.converters import json_compatible
 from Products.PlonePAS.tools.groupdata import GroupData
-from typing import List
 
 
-def export_groups() -> List[dict]:
+def export_groups() -> list[dict]:
     """Return all groups."""
     data = []
     all_groups = get_all_groups()
@@ -23,7 +22,7 @@ def export_groups() -> List[dict]:
     return data
 
 
-def import_groups(data: List[dict]) -> List[GroupData]:
+def import_groups(data: list[dict]) -> list[GroupData]:
     """Import groups."""
     groups = []
     acl = api.portal.get_tool("acl_users")

--- a/src/plone/exportimport/utils/principals/helpers.py
+++ b/src/plone/exportimport/utils/principals/helpers.py
@@ -6,7 +6,6 @@ from Products.PlonePAS.tools.groupdata import GroupData
 from typing import List
 from typing import Optional
 
-
 _sort_key_id = attrgetter("id")
 
 

--- a/src/plone/exportimport/utils/principals/helpers.py
+++ b/src/plone/exportimport/utils/principals/helpers.py
@@ -3,8 +3,6 @@ from plone import api
 from plone.exportimport.settings import AUTO_GROUPS
 from plone.exportimport.settings import AUTO_ROLES
 from Products.PlonePAS.tools.groupdata import GroupData
-from typing import List
-from typing import Optional
 
 _sort_key_id = attrgetter("id")
 
@@ -17,7 +15,7 @@ def get_roles_for_group(group: GroupData, filter: bool = True) -> list:
     return sorted(roles)
 
 
-def get_roles_for_member(member, filter: bool = True) -> List[str]:
+def get_roles_for_member(member, filter: bool = True) -> list[str]:
     """Return a list of roles for a given member."""
     roles = [r for r in member.getRoles()]
     if filter:
@@ -26,8 +24,8 @@ def get_roles_for_member(member, filter: bool = True) -> List[str]:
 
 
 def get_all_groups(
-    username: str = "", group: Optional[GroupData] = None, filter: bool = True
-) -> List[GroupData]:
+    username: str = "", group: GroupData | None = None, filter: bool = True
+) -> list[GroupData]:
     """Get groups."""
     payload = {}
     if username:

--- a/src/plone/exportimport/utils/principals/members.py
+++ b/src/plone/exportimport/utils/principals/members.py
@@ -6,7 +6,6 @@ from plone.exportimport.utils.principals import helpers
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFPlone.RegistrationTool import RegistrationTool
 from Products.PlonePAS.tools.memberdata import MemberData
-from typing import List
 from zope.schema import getFieldNames
 
 
@@ -34,7 +33,7 @@ def _run_as_manager(context: RegistrationTool):
             context.manage_setLocalRoles(current_user.getId(), list(local_roles))
 
 
-def _get_user_schema_fields() -> List[str]:
+def _get_user_schema_fields() -> list[str]:
     """List of fields/properties used in User Schema."""
     schema = getUserDataSchema()
     fields = [name for name in getFieldNames(schema)]
@@ -50,7 +49,7 @@ def _get_user_password(member: MemberData):
     return password.decode("utf-8") if isinstance(password, bytes) else password
 
 
-def _get_user_properties(member: MemberData, fields: List[str]) -> dict:
+def _get_user_properties(member: MemberData, fields: list[str]) -> dict:
     props = {}
     for prop in fields:
         if prop in ("portrait", "pdelete"):
@@ -84,7 +83,7 @@ def _get_base_user_data(member: MemberData):
     return props
 
 
-def export_members() -> List[dict]:
+def export_members() -> list[dict]:
     """Serialize all members as a list of dictionaries."""
     acl_users = api.portal.get_tool("acl_users")
     fields = _get_user_schema_fields()
@@ -108,7 +107,7 @@ def export_members() -> List[dict]:
     return data
 
 
-def import_members(data: List[dict]) -> MemberData:
+def import_members(data: list[dict]) -> MemberData:
     """Import member information from the provided list of dictionaries."""
     members = []
     pr = api.portal.get_tool("portal_registration")

--- a/src/plone/exportimport/utils/redirects.py
+++ b/src/plone/exportimport/utils/redirects.py
@@ -1,7 +1,6 @@
 from plone.app.redirector.interfaces import IRedirectionStorage
 from plone.app.redirector.storage import RedirectionStorage
 from plone.exportimport import logger
-from typing import Dict
 from zope.component import getUtility
 
 
@@ -10,7 +9,7 @@ def _get_storage() -> RedirectionStorage:
     return getUtility(IRedirectionStorage)
 
 
-def get_redirects() -> Dict[str, str]:
+def get_redirects() -> dict[str, str]:
     """Get a mapping of all redirects in a Plone site."""
     redirects = {}
     storage = _get_storage()
@@ -21,7 +20,7 @@ def get_redirects() -> Dict[str, str]:
     return redirects
 
 
-def set_redirects(redirects: Dict[str, str]) -> Dict[str, str]:
+def set_redirects(redirects: dict[str, str]) -> dict[str, str]:
     """Set a mapping of redirects in a Plone site."""
     storage = _get_storage()
     for key, value in redirects.items():

--- a/src/plone/exportimport/utils/relations.py
+++ b/src/plone/exportimport/utils/relations.py
@@ -4,7 +4,6 @@ from operator import itemgetter
 from plone import api
 from plone.dexterity.content import DexterityContent
 from Products.CMFPlone import relationhelper
-from typing import List
 from z3c.relationfield.index import RelationCatalog
 from z3c.relationfield.interfaces import IRelationChoice
 from z3c.relationfield.interfaces import IRelationList
@@ -63,9 +62,9 @@ def _relation_sort_key(rel: dict) -> tuple:
 
 def get_relations(
     debug: bool = False, include_linkintegrity: bool = True
-) -> List[dict]:
+) -> list[dict]:
     results = []
-    all_relations: List[dict] = relationhelper.get_all_relations()
+    all_relations: list[dict] = relationhelper.get_all_relations()
     for rel in all_relations:
         if not _should_export_relation(rel, include_linkintegrity):
             continue
@@ -75,7 +74,7 @@ def get_relations(
     return sorted(results, key=_relation_sort_key)
 
 
-def _prepare_relations_to_import(data: List[dict]) -> List[dict]:
+def _prepare_relations_to_import(data: list[dict]) -> list[dict]:
     """Prepare relations data to be imported into a Plone site.
 
     - Filter relations that should not be imported.
@@ -96,7 +95,7 @@ def _prepare_relations_to_import(data: List[dict]) -> List[dict]:
     return all_fixed_relations
 
 
-def set_relations(data: List[dict]) -> List[dict]:
+def set_relations(data: list[dict]) -> list[dict]:
     """Import relations listed in data into the current Plone site."""
     all_fixed_relations = _prepare_relations_to_import(data)
     relationhelper.purge_relations()

--- a/src/plone/exportimport/utils/relations.py
+++ b/src/plone/exportimport/utils/relations.py
@@ -11,7 +11,6 @@ from z3c.relationfield.interfaces import IRelationList
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 
-
 RELATIONS_TO_IGNORE = [
     "translationOf",  # old LinguaPlone
     "internal_references",  # obsolete

--- a/src/plone/exportimport/utils/translations.py
+++ b/src/plone/exportimport/utils/translations.py
@@ -9,7 +9,6 @@ from typing import Tuple
 
 import operator
 
-
 try:
     from plone.app.multilingual.interfaces import ITranslationManager
 except ImportError:

--- a/src/plone/exportimport/utils/translations.py
+++ b/src/plone/exportimport/utils/translations.py
@@ -4,8 +4,6 @@ from plone import api
 from plone.dexterity.content import DexterityContent
 from plone.exportimport import logger
 from Products.CMFPlone.CatalogTool import CatalogTool
-from typing import List
-from typing import Tuple
 
 import operator
 
@@ -29,7 +27,7 @@ def has_translation_support(portal_catalog: CatalogTool) -> bool:
     return has_translation_support
 
 
-def _get_all_translation_groups(portal_catalog: CatalogTool) -> Tuple[str]:
+def _get_all_translation_groups(portal_catalog: CatalogTool) -> tuple[str]:
     """Return a list of all translation groups uid in the catalog."""
     if not has_translation_support(portal_catalog):
         return ()
@@ -45,7 +43,7 @@ def _prepare_translation_group(default_language: str, translations: dict) -> dic
     return {"canonical": canonical, "translations": translations}
 
 
-def get_translations(paths_to_drop: List[str] = None) -> List[dict]:
+def get_translations(paths_to_drop: list[str] = None) -> list[dict]:
     """Get all translations."""
     paths_to_drop = paths_to_drop if paths_to_drop else []
     results = []
@@ -114,7 +112,7 @@ def link_translations(
     return True
 
 
-def set_translations(data: List[dict]) -> List[dict]:
+def set_translations(data: list[dict]) -> list[dict]:
     """Process a list of translations and add them to the Plone site."""
     results = []
     if not HAS_MULTILINGUAL:

--- a/src/plone/exportimport/utils/zip_utils.py
+++ b/src/plone/exportimport/utils/zip_utils.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from typing import BinaryIO
-from typing import Optional
 
 import tempfile
 import zipfile
@@ -10,7 +9,7 @@ import zipfile
 
 def export_to_zip(
     export_path: Path,
-    output_file: Optional[BinaryIO] = None,
+    output_file: BinaryIO | None = None,
 ) -> BinaryIO:
     """Compress an export directory into a ZIP file.
 
@@ -45,7 +44,7 @@ def export_to_zip(
 
 def import_from_zip(
     zip_file: BinaryIO,
-    import_path: Optional[Path] = None,
+    import_path: Path | None = None,
 ) -> Path:
     """Extract a ZIP file into a directory for import.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,10 @@
+from collections.abc import Callable
 from pathlib import Path
 from plone import api
 from plone.app.multilingual.browser.setup import SetupMultilingualSite
 from plone.exportimport.testing import FUNCTIONAL_TESTING
 from plone.exportimport.testing import INTEGRATION_TESTING
 from pytest_plone import fixtures_factory
-from typing import Callable
-from typing import List
-from typing import Union
 
 import json
 import pytest
@@ -65,7 +63,7 @@ def export_path(tmp_path) -> Path:
 
 @pytest.fixture
 def paths_as_relative():
-    def func(base_path: Path, paths: List[Path]) -> List[str]:
+    def func(base_path: Path, paths: list[Path]) -> list[str]:
         return [str(path.relative_to(base_path).as_posix()) for path in paths]
 
     return func
@@ -73,7 +71,7 @@ def paths_as_relative():
 
 @pytest.fixture
 def load_json():
-    def func(base_path: Path, path: Path) -> Union[dict, list]:
+    def func(base_path: Path, path: Path) -> dict | list:
         with open(base_path / path) as fh:
             data = json.load(fh)
         return data
@@ -133,7 +131,7 @@ def create_example_content():
 
 @pytest.fixture
 def setup_discussion():
-    def func(types: List[str]):
+    def func(types: list[str]):
         portal_setup = api.portal.get_tool("portal_setup")
         portal_setup.runAllImportStepsFromProfile(
             "profile-plone.app.discussion:default"
@@ -192,7 +190,7 @@ def portal_multilingual(portal, setup_multilingual_site):
 
 
 @pytest.fixture()
-def groups() -> List[dict]:
+def groups() -> list[dict]:
     """New groups."""
     return [
         {
@@ -213,7 +211,7 @@ def groups() -> List[dict]:
 
 
 @pytest.fixture()
-def users() -> List[dict]:
+def users() -> list[dict]:
     """New users."""
     return [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from typing import Union
 import json
 import pytest
 
-
 pytest_plugins = ["pytest_plone"]
 
 

--- a/tests/exporters/test_exporters_portlets.py
+++ b/tests/exporters/test_exporters_portlets.py
@@ -3,7 +3,6 @@ from zope.component import getAdapter
 
 import pytest
 
-
 try:
     from plone.exportimport.exporters import portlets
 except ImportError:

--- a/tests/importers/test_importers_portlets.py
+++ b/tests/importers/test_importers_portlets.py
@@ -3,7 +3,6 @@ from zope.component import getAdapter
 
 import pytest
 
-
 try:
     from plone.exportimport.importers import portlets
 except ImportError:

--- a/tests/utils/test_utils_content_export_helpers.py
+++ b/tests/utils/test_utils_content_export_helpers.py
@@ -5,7 +5,6 @@ from plone.exportimport.utils.content import export_helpers
 
 import pytest
 
-
 PORTAL_URL = "http://nohost/plone"
 
 

--- a/tests/utils/test_utils_dates.py
+++ b/tests/utils/test_utils_dates.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from DateTime import DateTime
 from plone.exportimport.utils import dates
-from typing import Tuple
 
 import pytest
 
@@ -38,7 +37,7 @@ def test_parse_datetime_failure(value: str):
         ["2024-01-31T22:16:32+00:00", (2024, 1, 31, 22, 16, 32, "GMT+0")],
     ],
 )
-def test_parse_date_success(value: str, parts: Tuple):
+def test_parse_date_success(value: str, parts: tuple):
     func = dates.parse_date
     result = func(value)
     assert isinstance(result, DateTime)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -7,6 +7,7 @@ min_version = 4.4.0
 envlist =
     lint
     test
+    py314-plone62
     py313-plone62
     py312-plone62
     py311-plone62
@@ -18,6 +19,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -65,9 +67,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -98,7 +100,7 @@ coverage =
 description = shared configuration for tests and coverage
 use_develop = true
 skip_install = false
-constrain_package_deps = false
+constrain_package_deps = true
 set_env =
     ROBOT_BROWSER=headlesschrome
 
@@ -135,6 +137,7 @@ extras =
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
* Configure with plone.meta.
* Fix error for an [invalid workflow file](https://github.com/plone/plone.exportimport/actions/runs/26044933092).
* Run black/isort/pyupgrade: remove typing imports for unsupported Python versions